### PR TITLE
Switch to Google hosted JQuery libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Rally Analytics #
 
+Some of the examples in the https://github.com/RallyCommunity/RallyAnalytics require JQuery and Highcharts libraries to function correctly.  As of June 1, 2016, these dependencies will no longer by hosted / provided by CA Technologies.  
+
+Potential options include hosting these libraries yourself or using community hosted versions (ex. https://ajax.googleapis.com/ajax/libs/jquery/1.6.1/jquery.min.js, http://code.highcharts.com/2.1.6/modules/exporting.js).
+
 Note, to run the examples in here, you'll need to launch Chrome with the following:
 
 On Mac

--- a/deploy/TIP.html
+++ b/deploy/TIP.html
@@ -64,7 +64,7 @@
         <!-- HighCharts -->
         <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.1/jquery.min.js"></script>
         <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.1/highcharts.js"></script>
-        <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.1/exporting.js"></script>
+        <script type="text/javascript" src="http://code.highcharts.com/2.1.6/modules/exporting.js"></script>
         <!-- a theme file
             <script type="text/javascript" src="../js/themes/gray.js"></script>
         -->

--- a/deploy/TIP.html
+++ b/deploy/TIP.html
@@ -62,9 +62,9 @@
         <title>Time In Process (TIP) Chart</title>
         
         <!-- HighCharts -->
-        <script type="text/javascript" src="https://people.rallydev.com/js/jquery.min.js"></script>
-        <script type="text/javascript" src="https://people.rallydev.com/js/highcharts.js"></script>
-        <script type="text/javascript" src="https://people.rallydev.com/js/exporting.js"></script>
+        <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.1/jquery.min.js"></script>
+        <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.1/highcharts.js"></script>
+        <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.1/exporting.js"></script>
         <!-- a theme file
             <script type="text/javascript" src="../js/themes/gray.js"></script>
         -->

--- a/deploy/burn-johndeere.html
+++ b/deploy/burn-johndeere.html
@@ -58,7 +58,7 @@
         <!-- HighCharts -->
         <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.1/jquery.min.js"></script>
         <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.1/highcharts.js"></script>
-        <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.1/exporting.js"></script>
+        <script type="text/javascript" src="http://code.highcharts.com/2.1.6/modules/exporting.js"></script>
         <!-- a theme file
             <script type="text/javascript" src="../js/themes/gray.js"></script>
         -->

--- a/deploy/burn-johndeere.html
+++ b/deploy/burn-johndeere.html
@@ -56,9 +56,9 @@
         <title>Burn</title>
         
         <!-- HighCharts -->
-        <script type="text/javascript" src="https://people.rallydev.com/js/jquery.min.js"></script>
-        <script type="text/javascript" src="https://people.rallydev.com/js/highcharts.js"></script>
-        <script type="text/javascript" src="https://people.rallydev.com/js/exporting.js"></script>
+        <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.1/jquery.min.js"></script>
+        <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.1/highcharts.js"></script>
+        <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.1/exporting.js"></script>
         <!-- a theme file
             <script type="text/javascript" src="../js/themes/gray.js"></script>
         -->

--- a/deploy/burn.html
+++ b/deploy/burn.html
@@ -63,7 +63,7 @@
         <!-- HighCharts -->
         <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.1/jquery.min.js"></script>
         <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.1/highcharts.js"></script>
-        <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.1/exporting.js"></script>
+        <script type="text/javascript" src="http://code.highcharts.com/2.1.6/modules/exporting.js"></script>
         <!-- a theme file
             <script type="text/javascript" src="../js/themes/gray.js"></script>
         -->

--- a/deploy/burn.html
+++ b/deploy/burn.html
@@ -61,9 +61,9 @@
         <title>Burn</title>
         
         <!-- HighCharts -->
-        <script type="text/javascript" src="https://people.rallydev.com/js/jquery.min.js"></script>
-        <script type="text/javascript" src="https://people.rallydev.com/js/highcharts.js"></script>
-        <script type="text/javascript" src="https://people.rallydev.com/js/exporting.js"></script>
+        <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.1/jquery.min.js"></script>
+        <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.1/highcharts.js"></script>
+        <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.1/exporting.js"></script>
         <!-- a theme file
             <script type="text/javascript" src="../js/themes/gray.js"></script>
         -->

--- a/deploy/cfd-old.html
+++ b/deploy/cfd-old.html
@@ -20,9 +20,9 @@ The general structure of the visualization examples in this repository follows t
         <title>Rally Cumulative Flow Example</title>
         
         <!-- HighCharts -->
-        <script type="text/javascript" src="https://people.rallydev.com/js/jquery.min.js"></script>
-        <script type="text/javascript" src="https://people.rallydev.com/js/highcharts.js"></script>
-        <script type="text/javascript" src="https://people.rallydev.com/js/exporting.js"></script>
+        <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.1/jquery.min.js"></script>
+        <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.1/highcharts.js"></script>
+        <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.1/exporting.js"></script>
         <!-- a theme file
             <script type="text/javascript" src="../js/themes/gray.js"></script>
         -->

--- a/deploy/cfd-old.html
+++ b/deploy/cfd-old.html
@@ -22,7 +22,7 @@ The general structure of the visualization examples in this repository follows t
         <!-- HighCharts -->
         <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.1/jquery.min.js"></script>
         <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.1/highcharts.js"></script>
-        <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.1/exporting.js"></script>
+        <script type="text/javascript" src="http://code.highcharts.com/2.1.6/modules/exporting.js"></script>
         <!-- a theme file
             <script type="text/javascript" src="../js/themes/gray.js"></script>
         -->

--- a/deploy/cfd.html
+++ b/deploy/cfd.html
@@ -65,9 +65,9 @@
         <title>CFD</title>
         
         <!-- HighCharts -->
-        <script type="text/javascript" src="https://people.rallydev.com/js/jquery.min.js"></script>
-        <script type="text/javascript" src="https://people.rallydev.com/js/highcharts.js"></script>
-        <script type="text/javascript" src="https://people.rallydev.com/js/exporting.js"></script>
+        <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.1/jquery.min.js"></script>
+        <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.1/highcharts.js"></script>
+        <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.1/exporting.js"></script>
         <!-- a theme file
             <script type="text/javascript" src="../js/themes/gray.js"></script>
         -->

--- a/deploy/cfd.html
+++ b/deploy/cfd.html
@@ -67,7 +67,7 @@
         <!-- HighCharts -->
         <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.1/jquery.min.js"></script>
         <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.1/highcharts.js"></script>
-        <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.1/exporting.js"></script>
+        <script type="text/javascript" src="http://code.highcharts.com/2.1.6/modules/exporting.js"></script>
         <!-- a theme file
             <script type="text/javascript" src="../js/themes/gray.js"></script>
         -->

--- a/deploy/throughput.html
+++ b/deploy/throughput.html
@@ -42,9 +42,9 @@
         <title>Throughput</title>
         
         <!-- HighCharts -->
-        <script type="text/javascript" src="https://people.rallydev.com/js/jquery.min.js"></script>
-        <script type="text/javascript" src="https://people.rallydev.com/js/highcharts.js"></script>
-        <script type="text/javascript" src="https://people.rallydev.com/js/exporting.js"></script>
+        <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.1/jquery.min.js"></script>
+        <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.1/highcharts.js"></script>
+        <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.1/exporting.js"></script>
         <!-- a theme file
             <script type="text/javascript" src="../js/themes/gray.js"></script>
         -->

--- a/deploy/throughput.html
+++ b/deploy/throughput.html
@@ -44,7 +44,7 @@
         <!-- HighCharts -->
         <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.1/jquery.min.js"></script>
         <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.1/highcharts.js"></script>
-        <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.1/exporting.js"></script>
+        <script type="text/javascript" src="http://code.highcharts.com/2.1.6/modules/exporting.js"></script>
         <!-- a theme file
             <script type="text/javascript" src="../js/themes/gray.js"></script>
         -->

--- a/examples/TIP.html
+++ b/examples/TIP.html
@@ -64,7 +64,7 @@
         <!-- HighCharts -->
         <script type="text/javascript" src="../lib/jquery.min.js" deploy_src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.1/jquery.min.js"></script>
         <script type="text/javascript" src="../lib/highcharts/js/highcharts.js" deploy_src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.1/highcharts.js"></script>
-        <script type="text/javascript" src="../lib/highcharts/js/modules/exporting.js" deploy_src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.1/exporting.js"></script>
+        <script type="text/javascript" src="../lib/highcharts/js/modules/exporting.js" deploy_src="http://code.highcharts.com/2.1.6/modules/exporting.js"></script>
         <!-- a theme file
             <script type="text/javascript" src="../js/themes/gray.js"></script>
         -->

--- a/examples/TIP.html
+++ b/examples/TIP.html
@@ -62,9 +62,9 @@
         <title>Time In Process (TIP) Chart</title>
         
         <!-- HighCharts -->
-        <script type="text/javascript" src="../lib/jquery.min.js" deploy_src="https://people.rallydev.com/js/jquery.min.js"></script>
-        <script type="text/javascript" src="../lib/highcharts/js/highcharts.js" deploy_src="https://people.rallydev.com/js/highcharts.js"></script>
-        <script type="text/javascript" src="../lib/highcharts/js/modules/exporting.js" deploy_src="https://people.rallydev.com/js/exporting.js"></script>
+        <script type="text/javascript" src="../lib/jquery.min.js" deploy_src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.1/jquery.min.js"></script>
+        <script type="text/javascript" src="../lib/highcharts/js/highcharts.js" deploy_src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.1/highcharts.js"></script>
+        <script type="text/javascript" src="../lib/highcharts/js/modules/exporting.js" deploy_src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.1/exporting.js"></script>
         <!-- a theme file
             <script type="text/javascript" src="../js/themes/gray.js"></script>
         -->

--- a/examples/burn-johndeere.html
+++ b/examples/burn-johndeere.html
@@ -58,7 +58,7 @@
         <!-- HighCharts -->
         <script type="text/javascript" src="../lib/jquery.min.js" deploy_src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.1/jquery.min.js"></script>
         <script type="text/javascript" src="../lib/highcharts/js/highcharts.js" deploy_src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.1/highcharts.js"></script>
-        <script type="text/javascript" src="../lib/highcharts/js/modules/exporting.js" deploy_src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.1/exporting.js"></script>
+        <script type="text/javascript" src="../lib/highcharts/js/modules/exporting.js" deploy_src="http://code.highcharts.com/2.1.6/modules/exporting.js"></script>
         <!-- a theme file
             <script type="text/javascript" src="../js/themes/gray.js"></script>
         -->

--- a/examples/burn-johndeere.html
+++ b/examples/burn-johndeere.html
@@ -56,9 +56,9 @@
         <title>Burn</title>
         
         <!-- HighCharts -->
-        <script type="text/javascript" src="../lib/jquery.min.js" deploy_src="https://people.rallydev.com/js/jquery.min.js"></script>
-        <script type="text/javascript" src="../lib/highcharts/js/highcharts.js" deploy_src="https://people.rallydev.com/js/highcharts.js"></script>
-        <script type="text/javascript" src="../lib/highcharts/js/modules/exporting.js" deploy_src="https://people.rallydev.com/js/exporting.js"></script>
+        <script type="text/javascript" src="../lib/jquery.min.js" deploy_src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.1/jquery.min.js"></script>
+        <script type="text/javascript" src="../lib/highcharts/js/highcharts.js" deploy_src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.1/highcharts.js"></script>
+        <script type="text/javascript" src="../lib/highcharts/js/modules/exporting.js" deploy_src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.1/exporting.js"></script>
         <!-- a theme file
             <script type="text/javascript" src="../js/themes/gray.js"></script>
         -->

--- a/examples/burn.html
+++ b/examples/burn.html
@@ -63,7 +63,7 @@
         <!-- HighCharts -->
         <script type="text/javascript" src="../lib/jquery.min.js" deploy_src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.1/jquery.min.js"></script>
         <script type="text/javascript" src="../lib/highcharts/js/highcharts.js" deploy_src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.1/highcharts.js"></script>
-        <script type="text/javascript" src="../lib/highcharts/js/modules/exporting.js" deploy_src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.1/exporting.js"></script>
+        <script type="text/javascript" src="../lib/highcharts/js/modules/exporting.js" deploy_src="http://code.highcharts.com/2.1.6/modules/exporting.js"></script>
         <!-- a theme file
             <script type="text/javascript" src="../js/themes/gray.js"></script>
         -->

--- a/examples/burn.html
+++ b/examples/burn.html
@@ -61,9 +61,9 @@
         <title>Burn</title>
         
         <!-- HighCharts -->
-        <script type="text/javascript" src="../lib/jquery.min.js" deploy_src="https://people.rallydev.com/js/jquery.min.js"></script>
-        <script type="text/javascript" src="../lib/highcharts/js/highcharts.js" deploy_src="https://people.rallydev.com/js/highcharts.js"></script>
-        <script type="text/javascript" src="../lib/highcharts/js/modules/exporting.js" deploy_src="https://people.rallydev.com/js/exporting.js"></script>
+        <script type="text/javascript" src="../lib/jquery.min.js" deploy_src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.1/jquery.min.js"></script>
+        <script type="text/javascript" src="../lib/highcharts/js/highcharts.js" deploy_src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.1/highcharts.js"></script>
+        <script type="text/javascript" src="../lib/highcharts/js/modules/exporting.js" deploy_src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.1/exporting.js"></script>
         <!-- a theme file
             <script type="text/javascript" src="../js/themes/gray.js"></script>
         -->

--- a/examples/cfd-old.html
+++ b/examples/cfd-old.html
@@ -20,9 +20,9 @@ The general structure of the visualization examples in this repository follows t
         <title>Rally Cumulative Flow Example</title>
         
         <!-- HighCharts -->
-        <script type="text/javascript" src="../lib/jquery.min.js" deploy_src="https://people.rallydev.com/js/jquery.min.js"></script>
-        <script type="text/javascript" src="../lib/highcharts/js/highcharts.js" deploy_src="https://people.rallydev.com/js/highcharts.js"></script>
-        <script type="text/javascript" src="../lib/highcharts/js/modules/exporting.js" deploy_src="https://people.rallydev.com/js/exporting.js"></script>
+        <script type="text/javascript" src="../lib/jquery.min.js" deploy_src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.1/jquery.min.js"></script>
+        <script type="text/javascript" src="../lib/highcharts/js/highcharts.js" deploy_src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.1/highcharts.js"></script>
+        <script type="text/javascript" src="../lib/highcharts/js/modules/exporting.js" deploy_src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.1/exporting.js"></script>
         <!-- a theme file
             <script type="text/javascript" src="../js/themes/gray.js"></script>
         -->

--- a/examples/cfd-old.html
+++ b/examples/cfd-old.html
@@ -22,7 +22,7 @@ The general structure of the visualization examples in this repository follows t
         <!-- HighCharts -->
         <script type="text/javascript" src="../lib/jquery.min.js" deploy_src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.1/jquery.min.js"></script>
         <script type="text/javascript" src="../lib/highcharts/js/highcharts.js" deploy_src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.1/highcharts.js"></script>
-        <script type="text/javascript" src="../lib/highcharts/js/modules/exporting.js" deploy_src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.1/exporting.js"></script>
+        <script type="text/javascript" src="../lib/highcharts/js/modules/exporting.js" deploy_src="http://code.highcharts.com/2.1.6/modules/exporting.js"></script>
         <!-- a theme file
             <script type="text/javascript" src="../js/themes/gray.js"></script>
         -->

--- a/examples/cfd.html
+++ b/examples/cfd.html
@@ -65,9 +65,9 @@
         <title>CFD</title>
         
         <!-- HighCharts -->
-        <script type="text/javascript" src="../lib/jquery.min.js" deploy_src="https://people.rallydev.com/js/jquery.min.js"></script>
-        <script type="text/javascript" src="../lib/highcharts/js/highcharts.js" deploy_src="https://people.rallydev.com/js/highcharts.js"></script>
-        <script type="text/javascript" src="../lib/highcharts/js/modules/exporting.js" deploy_src="https://people.rallydev.com/js/exporting.js"></script>
+        <script type="text/javascript" src="../lib/jquery.min.js" deploy_src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.1/jquery.min.js"></script>
+        <script type="text/javascript" src="../lib/highcharts/js/highcharts.js" deploy_src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.1/highcharts.js"></script>
+        <script type="text/javascript" src="../lib/highcharts/js/modules/exporting.js" deploy_src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.1/exporting.js"></script>
         <!-- a theme file
             <script type="text/javascript" src="../js/themes/gray.js"></script>
         -->

--- a/examples/cfd.html
+++ b/examples/cfd.html
@@ -67,7 +67,7 @@
         <!-- HighCharts -->
         <script type="text/javascript" src="../lib/jquery.min.js" deploy_src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.1/jquery.min.js"></script>
         <script type="text/javascript" src="../lib/highcharts/js/highcharts.js" deploy_src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.1/highcharts.js"></script>
-        <script type="text/javascript" src="../lib/highcharts/js/modules/exporting.js" deploy_src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.1/exporting.js"></script>
+        <script type="text/javascript" src="../lib/highcharts/js/modules/exporting.js" deploy_src="http://code.highcharts.com/2.1.6/modules/exporting.js"></script>
         <!-- a theme file
             <script type="text/javascript" src="../js/themes/gray.js"></script>
         -->

--- a/examples/throughput.html
+++ b/examples/throughput.html
@@ -42,9 +42,9 @@
         <title>Throughput</title>
         
         <!-- HighCharts -->
-        <script type="text/javascript" src="../lib/jquery.min.js" deploy_src="https://people.rallydev.com/js/jquery.min.js"></script>
-        <script type="text/javascript" src="../lib/highcharts/js/highcharts.js" deploy_src="https://people.rallydev.com/js/highcharts.js"></script>
-        <script type="text/javascript" src="../lib/highcharts/js/modules/exporting.js" deploy_src="https://people.rallydev.com/js/exporting.js"></script>
+        <script type="text/javascript" src="../lib/jquery.min.js" deploy_src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.1/jquery.min.js"></script>
+        <script type="text/javascript" src="../lib/highcharts/js/highcharts.js" deploy_src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.1/highcharts.js"></script>
+        <script type="text/javascript" src="../lib/highcharts/js/modules/exporting.js" deploy_src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.1/exporting.js"></script>
         <!-- a theme file
             <script type="text/javascript" src="../js/themes/gray.js"></script>
         -->

--- a/examples/throughput.html
+++ b/examples/throughput.html
@@ -44,7 +44,7 @@
         <!-- HighCharts -->
         <script type="text/javascript" src="../lib/jquery.min.js" deploy_src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.1/jquery.min.js"></script>
         <script type="text/javascript" src="../lib/highcharts/js/highcharts.js" deploy_src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.1/highcharts.js"></script>
-        <script type="text/javascript" src="../lib/highcharts/js/modules/exporting.js" deploy_src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.1/exporting.js"></script>
+        <script type="text/javascript" src="../lib/highcharts/js/modules/exporting.js" deploy_src="http://code.highcharts.com/2.1.6/modules/exporting.js"></script>
         <!-- a theme file
             <script type="text/javascript" src="../js/themes/gray.js"></script>
         -->


### PR DESCRIPTION
Removing people.rallydev.com dependency since it's not hosted on a production server.  Switching to Google hosted libraries will ensure the availability of this dependency.  
